### PR TITLE
Add install note for fswatch

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,7 +32,25 @@ final class Plugin implements HandlesArguments
 
         $loop    = Factory::create();
         $watcher = new Watch($loop, 'tests');
-        $watcher->run();
+
+        try {
+            $watcher->run();
+        } catch (\LogicException $exception) {
+            if ($exception->getMessage() !== 'fswatch not found') {
+                throw $exception;
+            }
+
+            $this->output->writeln(sprintf(
+                '  <fg=black;bg=red>[WARNING] %s</>',
+                'fswatch is required',
+            ));
+            $this->output->writeln(sprintf(
+                "\n  Install it from: %s",
+                'https://github.com/emcrisostomo/fswatch#getting-fswatch',
+            ));
+
+            exit(1);
+        }
 
         unset($originals[array_search('--watch', $originals, true)]);
         $command = implode(' ', $originals);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -71,8 +71,7 @@ final class Plugin implements HandlesArguments
         }
 
         $this->output->writeln(sprintf(
-            '  <fg=black;bg=red>[WARNING] %s</>',
-            'fswatch is required',
+            "\n  <fg=white;bg=red;options=bold> ERROR </> fswatch was not found.</>",
         ));
 
         $this->output->writeln(sprintf(

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,27 +30,11 @@ final class Plugin implements HandlesArguments
             return $originals;
         }
 
+        $this->checkFswatchIsAvailable();
+
         $loop    = Factory::create();
         $watcher = new Watch($loop, 'tests');
-
-        try {
-            $watcher->run();
-        } catch (\LogicException $exception) {
-            if ($exception->getMessage() !== 'fswatch not found') {
-                throw $exception;
-            }
-
-            $this->output->writeln(sprintf(
-                '  <fg=black;bg=red>[WARNING] %s</>',
-                'fswatch is required',
-            ));
-            $this->output->writeln(sprintf(
-                "\n  Install it from: %s",
-                'https://github.com/emcrisostomo/fswatch#getting-fswatch',
-            ));
-
-            exit(1);
-        }
+        $watcher->run();
 
         unset($originals[array_search('--watch', $originals, true)]);
         $command = implode(' ', $originals);
@@ -76,5 +60,26 @@ final class Plugin implements HandlesArguments
         $loop->run();
 
         exit(0);
+    }
+
+    private function checkFswatchIsAvailable(): void
+    {
+        exec('fswatch 2>&1', $output);
+
+        if (strpos(implode(' ', $output), 'command not found') === false) {
+            return;
+        }
+
+        $this->output->writeln(sprintf(
+            '  <fg=black;bg=red>[WARNING] %s</>',
+            'fswatch is required',
+        ));
+
+        $this->output->writeln(sprintf(
+            "\n  Install it from: %s",
+            'https://github.com/emcrisostomo/fswatch#getting-fswatch',
+        ));
+
+        exit(1);
     }
 }

--- a/src/Watch.php
+++ b/src/Watch.php
@@ -43,25 +43,11 @@ final class Watch implements EventEmitterInterface
     }
 
     /**
-     * Check if fswatch is available.
-     */
-    public function isAvailable(): bool
-    {
-        exec('fswatch 2>&1', $output);
-
-        return strpos(implode(' ', $output), 'command not found') === false;
-    }
-
-    /**
      * Run the ReactPHP loop function with the change
      * event listener.
      */
     public function run(): void
     {
-        if (!$this->isAvailable()) {
-            throw new \LogicException('fswatch is required');
-        }
-
         $this->process = new Process($this->command);
 
         $this->process->start($this->loop);


### PR DESCRIPTION
This also moves the `isAvailable()` check so that it's called before the `Watch` instance is created.

Although, as `isAvailable()` was a public method, I'm not sure if it was intended to be used elsewhere. If this is the case, I'll revert that.

Closes #6 