### PR TITLE
Update to watch 'app' and 'src' directories

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class Plugin implements HandlesArguments
 {
+    public const WATCHED_DIRECTORIES = ['app', 'src', 'tests'];
+
     /**
      * @var OutputInterface
      */
@@ -33,7 +35,7 @@ final class Plugin implements HandlesArguments
         $this->checkFswatchIsAvailable();
 
         $loop    = Factory::create();
-        $watcher = new Watch($loop, 'tests');
+        $watcher = new Watch($loop, self::WATCHED_DIRECTORIES);
         $watcher->run();
 
         unset($originals[array_search('--watch', $originals, true)]);

--- a/src/Watch.php
+++ b/src/Watch.php
@@ -34,12 +34,14 @@ final class Watch implements EventEmitterInterface
     /**
      * Starts a new watch on ths given folder.
      *
+     * @param array<int, string> $folders
+     *
      * @return void
      */
-    public function __construct(LoopInterface $loop, string $folder)
+    public function __construct(LoopInterface $loop, array $folders)
     {
         $this->loop    = $loop;
-        $this->command = sprintf('fswatch --recursive %s', $folder);
+        $this->command = sprintf('fswatch --recursive %s', implode(' ', $folders));
     }
 
     /**


### PR DESCRIPTION
This updates the watcher to watch the `app` and `src` directories by default, as well as `tests`.

Closes #4