### PR TITLE
feat: add support for specifying watch directories

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,9 @@ use Pest\Contracts\Plugins\HandlesArguments;
 use Pest\Support\Str;
 use React\ChildProcess\Process;
 use React\EventLoop\Factory;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -17,12 +20,15 @@ final class Plugin implements HandlesArguments
 {
     public const WATCHED_DIRECTORIES = ['app', 'src', 'tests'];
 
-    private const WATCH_DIRS_OPTION = 'watch-dirs';
+    private const WATCH_OPTION = 'watch';
 
     /**
      * @var OutputInterface
      */
     private $output;
+
+    /** @var array<int, string> */
+    private $watchedDirectories = self::WATCHED_DIRECTORIES;
 
     public function __construct(OutputInterface $output)
     {
@@ -31,32 +37,37 @@ final class Plugin implements HandlesArguments
 
     public function handleArguments(array $originals): array
     {
-        if (!in_array('--watch', $originals, true)) {
+        $arguments = array_merge([''], array_values(array_filter($originals, function ($original): bool {
+            return $original === sprintf('--%s', self::WATCH_OPTION) || Str::startsWith($original, sprintf('--%s=', self::WATCH_OPTION));
+        })));
+
+        $originals = array_flip($originals);
+        foreach ($arguments as $argument) {
+            unset($originals[$argument]);
+        }
+        $originals = array_flip($originals);
+
+        $inputs   = [];
+        $inputs[] = new InputOption(self::WATCH_OPTION, null, InputOption::VALUE_OPTIONAL, '', true);
+
+        $input = new ArgvInput($arguments, new InputDefinition($inputs));
+
+        if (!$input->hasParameterOption(sprintf('--%s', self::WATCH_OPTION))) {
             return $originals;
+        }
+
+        if ($input->getOption(self::WATCH_OPTION) !== null) {
+            /** @var string $directories */
+            $directories              = $input->getOption(self::WATCH_OPTION);
+            $this->watchedDirectories = explode(',', $directories);
         }
 
         $this->checkFswatchIsAvailable();
 
-        $watchedDirectories = self::WATCHED_DIRECTORIES;
-
-        if (($additionalWatchDirectories = $this->watchDirectories($originals)) !== []) {
-            foreach ($additionalWatchDirectories as $key => $directories) {
-                $watchedDirectories = array_merge(
-                    $watchedDirectories,
-                    explode(',', str_replace(sprintf('--%s=', self::WATCH_DIRS_OPTION), '', $directories)),
-                );
-
-                unset($originals[$key]);
-            }
-
-            $watchedDirectories = array_unique($watchedDirectories);
-        }
-
         $loop    = Factory::create();
-        $watcher = new Watch($loop, $watchedDirectories);
+        $watcher = new Watch($loop, $this->watchedDirectories);
         $watcher->run();
 
-        unset($originals[array_search('--watch', $originals, true)]);
         $command = implode(' ', $originals);
 
         $output  = $this->output;
@@ -100,17 +111,5 @@ final class Plugin implements HandlesArguments
         ));
 
         exit(1);
-    }
-
-    /**
-     * @param array<int, string> $originals
-     *
-     * @return array<int, string>
-     */
-    private function watchDirectories(array $originals): array
-    {
-        return array_filter($originals, static function ($value): bool {
-            return Str::startsWith($value, sprintf('--%s', self::WATCH_DIRS_OPTION));
-        });
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,7 +39,7 @@ final class Plugin implements HandlesArguments
 
         $watchedDirectories = self::WATCHED_DIRECTORIES;
 
-        if (($additionalWatchDirectories = $this->watchDirectories($originals)) && !empty($additionalWatchDirectories)) {
+        if (($additionalWatchDirectories = $this->watchDirectories($originals)) !== []) {
             foreach ($additionalWatchDirectories as $key => $directories) {
                 $watchedDirectories = array_merge(
                     $watchedDirectories,
@@ -100,9 +100,14 @@ final class Plugin implements HandlesArguments
         exit(1);
     }
 
+    /**
+     * @param array<int, string> $originals
+     *
+     * @return array<int, string>
+     */
     private function watchDirectories(array $originals): array
     {
-        return array_filter($originals, static function ($value) {
+        return array_filter($originals, static function ($value): bool {
             return Str::startsWith($value, sprintf('--%s', self::WATCH_DIRS_OPTION));
         });
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -48,6 +48,8 @@ final class Plugin implements HandlesArguments
 
                 unset($originals[$key]);
             }
+
+            $watchedDirectories = array_unique($watchedDirectories);
         }
 
         $loop    = Factory::create();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,13 +56,12 @@ final class Plugin implements HandlesArguments
             return $originals;
         }
 
-        if ($input->getOption(self::WATCH_OPTION) !== null) {
-            /** @var string $directories */
-            $directories              = $input->getOption(self::WATCH_OPTION);
-            $this->watchedDirectories = explode(',', $directories);
-        }
-
         $this->checkFswatchIsAvailable();
+
+        if ($input->getOption(self::WATCH_OPTION) !== null) {
+            /* @phpstan-ignore-next-line */
+            $this->watchedDirectories = explode(',', $input->getOption(self::WATCH_OPTION));
+        }
 
         $loop    = Factory::create();
         $watcher = new Watch($loop, $this->watchedDirectories);


### PR DESCRIPTION
This adds support for specifying additional directories to watch from the command line. It supports a comma-separated list of directories. For example:

```bash
pest --watch --watch-dirs=database/factories,resources/fonts
```