### PR TITLE
Update fswatch arguments to remove the infinite loop on Ubuntu

### DIFF
--- a/src/Watch.php
+++ b/src/Watch.php
@@ -40,7 +40,7 @@ final class Watch implements EventEmitterInterface
     public function __construct(LoopInterface $loop, array $folders)
     {
         $this->loop = $loop;
-        $this->command = sprintf('fswatch --recursive %s', implode(' ', $folders));
+        $this->command = sprintf('fswatch --recursive --follow-links --event Updated --event Created --event Removed %s', implode(' ', $folders));
     }
 
     /**


### PR DESCRIPTION
On Ubunutu, and presumably other Linuxes, fswatch triggers even for directory accesses, resulting in an infinite loop (https://github.com/pestphp/pest-plugin-watch/issues/7#issuecomment-894317561). 

This change filters fswatch events to only those when a file/dir is created, removed, or added.