### PR TITLE
Add support for --test-directory argument

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -69,6 +69,10 @@ final class Plugin implements HandlesArguments
         $watcher->run();
 
         $command = implode(' ', $originals);
+        $matches = preg_grep('/^--test-directory=.*/', $_SERVER['argv']);
+        if ($matches) {
+            $command .= ' ' . array_pop($matches);
+        }
 
         $output = $this->output;
 


### PR DESCRIPTION
Some arguments are not passed to plugins like the `--test-directory` param.  When someone depends on this setting for a normal run the watcher will not work because the argument will never be passed to the command in the loop.