### PR TITLE
Fix colors & fswatch error condition

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -106,7 +106,7 @@ final class Plugin implements HandlesArguments
     {
         exec('fswatch 2>&1', $output);
 
-        if (strpos(implode(' ', $output), 'command not found') === false) {
+        if (strpos(implode(' ', $output), 'not found') === false) {
             return;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -70,6 +70,10 @@ final class Plugin implements HandlesArguments
 
         $command = implode(' ', $originals);
 
+        if(strpos($command, '--colors=') === false) {
+            $command .= ' --colors=always';
+        }
+
         $output = $this->output;
 
         $watcher->on('change', static function () use ($command, $output): void {


### PR DESCRIPTION
Fixing two issues that are addressed here https://github.com/pestphp/pest/issues/789:

- `--watch` does not show colors.

- When `fswatch` is not installed, the condition inside `checkFswatchIsAvailable()` fails, therefore it runs the tests once and doesn't give an error message. This is the message that was given from running `fswatch` in my Ubuntu 20 (WSL):

![image](https://github.com/pestphp/pest-plugin-watch/assets/38707148/c76afeb8-52f2-4b31-87a0-21a17cf44e22)